### PR TITLE
Feature/calc scores

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,4 +32,4 @@ env/
 # Miscellaneous
 .DS_Store
 backup/
-tests/
+others/

--- a/meteothek/calc/fractions.py
+++ b/meteothek/calc/fractions.py
@@ -82,6 +82,8 @@ def convolve2Dimage(field, kernel, max_missing=0.25, method="integral", verbose=
 
     # Normalise by dividing with the fraction of valid points in a kernel
     # Ensure the result is computed using only valid grid points when the kernel window contains missing values.
+    # Replace zero values with NaN to avoid divide-by-zero warning
+    valid_conv = np.where(valid_conv == 0, np.nan, valid_conv)
     result = result / valid_conv
 
     # Mask with <valid_threshold>. Values are kept only when a window kernel contains enough valid grid points.

--- a/meteothek/calc/fractions.py
+++ b/meteothek/calc/fractions.py
@@ -11,7 +11,7 @@ from scipy import signal
 logger = logging.getLogger(__name__)
 
 
-def convolve2DFFT(field, kernel, max_missing=0.25, verbose=False):
+def convolve2Dimage(field, kernel, max_missing=0.25, method="integral", verbose=False):
     """perform safe 2D FFT convolution with NaN value handling.
 
     By nature of FFT, nan values are not allowed in fft convolution. This function performs convolution of a 2D field
@@ -51,11 +51,19 @@ def convolve2DFFT(field, kernel, max_missing=0.25, verbose=False):
     valid_field = 1 - np.isnan(field)
     # Detect nan values in the kernel (Valid =1, Nan=0) (usually kernel has no nan, but for security)
     valid_kernel = np.where(kernel == 0, 0, 1)
+
     # Calculate fractions of valid grid points in a kernel window
     # Note: mode='same' or 'full' does not affect FSS calculation, but 'same' is needed for the normalisation later.
-    valid_conv = signal.fftconvolve(valid_field, valid_kernel, mode="same") / (
-        valid_kernel.shape[0] * valid_kernel.shape[1]
-    )
+    if method == "fft":
+        valid_conv = signal.fftconvolve(valid_field, valid_kernel, mode="same")
+    elif method == "integral":
+        valid_conv = integralImage(valid_field, valid_kernel)
+    else:
+        raise Exception('Invalid convolution method: select "fft" or "integral" ')
+
+    # valid_field is always 0/1 integer-valued, so the true count inside every
+    # window is an exact integer.
+    valid_conv = np.round(valid_conv) / (valid_kernel.shape[0] * valid_kernel.shape[1])
     # If valid_conv is less than valid_threshold, that (convoluted) grid point will be discarded.
     # Calculate the valid threshold here
     valid_threshold = 1.0 - max_missing
@@ -65,7 +73,13 @@ def convolve2DFFT(field, kernel, max_missing=0.25, verbose=False):
     field = np.where(valid_field == 1, field, 0)
 
     # Make a convolution and masking the result by <result_mask>
-    result = signal.fftconvolve(field, kernel, mode="same")
+    if method == "fft":
+        result = signal.fftconvolve(field, kernel, mode="same")
+    elif method == "integral":
+        result = integralImage(field, kernel)
+    else:
+        raise Exception('Invalid convolution method: select "fft" or "integral" ')
+
     # Normalise by dividing with the fraction of valid points in a kernel
     # Ensure the result is computed using only valid grid points when the kernel window contains missing values.
     result = result / valid_conv
@@ -77,7 +91,73 @@ def convolve2DFFT(field, kernel, max_missing=0.25, verbose=False):
     return result
 
 
-def fss(fcst, obs, threshold, window, thrsd_type, max_missing=0.25):
+def integralImage(field, kernel, table=None):
+    """perform convolution using integral image (summed-area table) method.
+    This is an alternative to FFT convolution, and can be faster for small kernels.
+    Implementation based on Faggian et al. (2015, doi: 10.54302/mausam.v66i3.555) and corrected by Necker et al. (2024, doi: 10.1002/qj.4824)
+
+
+    Parameter
+    ---------
+    field : 2d nd-darray,
+        a field be convoluted.
+    kernel : 2d nd-array,
+        convolution kernel.
+    table : 2d nd-array, optional
+        pre-computed integral table. If not provided, it will be computed internally.
+
+    Returns
+    -------
+    result : 2d nd-array, convolution.
+    """
+
+    assert np.ndim(field) == 2, "<field> needs to be 2D."
+    assert np.ndim(kernel) == 2, "<kernel> needs to be 2D."
+    assert kernel.shape[0] <= field.shape[0], "<kernel> size needs to <= <field> size."
+    assert kernel.shape[1] <= field.shape[1], "<kernel> size needs to <= <field> size."
+    assert kernel.shape[0] == kernel.shape[1], "<kernel> needs to be square."
+
+    n = kernel.shape[0]
+    lw = n // 2   # left/top half-width (index of kernel centre from left edge)
+    rw = n - lw   # right/bottom half-width (exclusive upper extent)
+    if lw < 1:
+        return field.astype(float)
+
+    rows, cols = field.shape
+
+    if table is None:  # compute integral table if not provided
+        # Accumulate in float64 to minimise cancellation errors in the SAT.
+        table = np.float64(field).cumsum(1).cumsum(0)
+
+    # Pad the prefix-sum table with a zero row on top and a zero column on the left.
+    # padded[i+1, j+1] == table[i, j], and padded[0, :] == padded[:, 0] == 0.
+    # This lets us use exclusive-bound SAT arithmetic without special-casing:
+    #   sum[r0..r1) x [c0..c1) = T[r1,c1] - T[r0,c1] - T[r1,c0] + T[r0,c0]
+    padded = np.zeros((rows + 1, cols + 1), dtype=np.float64)
+    padded[1:, 1:] = table
+
+    # Build 1-D index vectors (length rows / cols) instead of full N×N grids.
+    # np.ix_ turns them into a pair of broadcast-compatible arrays so that
+    # padded[np.ix_(r1, c1)] gives an (rows×cols) outer-product lookup without
+    # any ravel_multi_index / np.take / flattening overhead.
+    ri = np.arange(rows, dtype=int)
+    cj = np.arange(cols, dtype=int)
+
+    # Exclusive lower/upper bounds in padded space.
+    # fftconvolve 'same' centres the kernel at index lw (= n//2) from its left
+    # edge, so the window for output pixel i spans [i-lw, i-lw+n) in field space,
+    # which maps to [i-lw+1, i-lw+n+1) = [i-lw, i+rw) in padded space after the
+    # zero-row/col shift.  Clipping to [0, rows/cols] handles boundaries.
+    r0 = np.clip(ri - lw, 0, rows)
+    r1 = np.clip(ri + rw, 0, rows)
+    c0 = np.clip(cj - lw, 0, cols)
+    c1 = np.clip(cj + rw, 0, cols)
+
+    return (padded[np.ix_(r1, c1)] + padded[np.ix_(r0, c0)]
+            - padded[np.ix_(r0, c1)] - padded[np.ix_(r1, c0)])
+
+
+def fss(fcst, obs, threshold, window, thrsd_type, max_missing=0.25, method="integral"):
     """
     Compute fractions skill score (FSS; Roberts and Lean, 2008) using convolution.
     Implementation based on Faggian et al. (2015, doi: 10.54302/mausam.v66i3.555)
@@ -125,18 +205,20 @@ def fss(fcst, obs, threshold, window, thrsd_type, max_missing=0.25):
     kernel = np.ones((window, window))
 
     if window > 1:
-        fhat = convolve2DFFT((fcst > thresh_fx), kernel, max_missing=max_missing)
-        ohat = convolve2DFFT((obs > thresh_obs), kernel, max_missing=max_missing)
+        fhat = convolve2Dimage((fcst > thresh_fx), kernel, max_missing=max_missing, method=method)
+        ohat = convolve2Dimage((obs > thresh_obs), kernel, max_missing=max_missing, method=method)
     else:
         fhat = fcst > thresh_fx
         ohat = obs > thresh_obs
 
     # Calculate FSS numerator and denominator
-    num = np.nanmean(np.power(fhat - ohat, 2))
-    denom = np.nanmean(np.power(fhat, 2) + np.power(ohat, 2))
-    
+    num = np.nanmean(np.power(np.float64(fhat) - np.float64(ohat), 2))
+    denom = np.nanmean(np.power(np.float64(fhat), 2) + np.power(np.float64(ohat), 2))
+
     mask = (~np.isnan(fhat)) & (~np.isnan(ohat))
-    logger.info(f"max_missing={max_missing}, {np.sum(1-mask)} grid points ({(1-np.nanmean(mask))* 100:.1f} %) are dropped.")
+    logger.info(
+        f"max_missing={max_missing}, {np.sum(1-mask)} grid points ({(1-np.nanmean(mask))* 100:.1f} %) are dropped."
+    )
 
     # return numerator, denominator, and FSS value
     return num, denom, 1.0 - num / denom

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "meteothek"
 dependencies = [
 "numpy",
-"xarray[complete]",
+"xarray",
 "scipy",
 "tqdm"
 ]

--- a/tests/benchmark_fss.py
+++ b/tests/benchmark_fss.py
@@ -1,0 +1,112 @@
+"""
+Speed benchmark: fss(method='fft') vs fss(method='integral').
+
+Runs each method REPEATS times for every window size in WINDOWS, prints a
+summary table, then checks that both methods produce numerically identical
+results for each window.
+"""
+import sys
+from pathlib import Path
+sys.path.insert(0, str(Path(__file__).parent.parent))
+import time
+import numpy as np
+from meteothek.calc import fss
+
+# ── Benchmark settings ────────────────────────────────────────────────────────
+REPEATS   = 300
+SHAPE     = (500, 500)          # field size
+THRESHOLD = 0.2                 # accumulation threshold
+WINDOWS   = [3, 5, 10, 15, 25, 50, 100]  # neighbourhood window sizes to test
+NAN_FRAC  = 0.05                # fraction of randomly placed NaNs
+SEED      = 0
+ABS_TOL   = 1e-9                # tolerance for result-match check
+# The SAT prefix-sum can reach O(N²×max_field) ≈ 200,000 for a 500×500 binary
+# field.  Float64 machine epsilon is ~2.2e-16, so absolute cancellation error in
+# a single SAT lookup is ~4e-11.  The FSS score is computed from means of squared
+# differences of such fractions, so combined errors from both SAT and FFT (which
+# also accumulates O(N²) internally) can exceed 1e-10 for large windows.  1e-9
+# is a conservative safe tolerance for this comparison.
+# ─────────────────────────────────────────────────────────────────────────────
+
+rng  = np.random.RandomState(SEED)
+fcst = rng.rand(*SHAPE)
+obs  = rng.rand(*SHAPE)
+# sprinkle NaNs
+fcst[rng.rand(*SHAPE) < NAN_FRAC] = np.nan
+obs [rng.rand(*SHAPE) < NAN_FRAC] = np.nan
+
+print(f"Field shape : {SHAPE}")
+print(f"Repeats     : {REPEATS}")
+print(f"Windows     : {WINDOWS}")
+print()
+
+
+def run_benchmark(method, window):
+    times = []
+    result = None
+    for _ in range(REPEATS):
+        t0 = time.perf_counter()
+        result = fss(fcst, obs, threshold=THRESHOLD, window=window,
+                     thrsd_type="accumulation", method=method)
+        times.append(time.perf_counter() - t0)
+    return result, np.array(times)
+
+
+# ── Run benchmarks for all window sizes ───────────────────────────────────────
+results = {}   # (window, method) -> (fss_result, times_array)
+for window in WINDOWS:
+    for method in ("fft", "integral"):
+        print(f"  window={window:>4},  method={method} …", flush=True)
+        results[(window, method)] = run_benchmark(method, window)
+
+# ── Timing table ──────────────────────────────────────────────────────────────
+col = 10   # column width for ms values
+header = (f"{'window':>8}  {'fft mean':>{col}}  {'int mean':>{col}}  "
+          f"{'fft min':>{col}}  {'int min':>{col}}  {'speedup':>8}  match")
+sep = "─" * len(header)
+print(f"\n{sep}")
+print(header)
+print(sep)
+
+match_failures = []
+for window in WINDOWS:
+    res_fft, t_fft = results[(window, "fft")]
+    res_int, t_int = results[(window, "integral")]
+
+    mean_fft = t_fft.mean() * 1e3
+    mean_int = t_int.mean() * 1e3
+    min_fft  = t_fft.min()  * 1e3
+    min_int  = t_int.min()  * 1e3
+    speedup  = mean_fft / mean_int   # >1 means integral is faster
+
+    # result-match check across num, denom, score
+    labels = ["num", "denom", "score"]
+    match_ok = True
+    fail_details = []
+    for i, (a, b) in enumerate(zip(res_fft, res_int)):
+        if np.isnan(a) and np.isnan(b):
+            continue
+        diff = abs(a - b)
+        if diff >= ABS_TOL:
+            match_ok = False
+            fail_details.append(f"{labels[i]}: |diff|={diff:.2e}")
+    match_str = "OK" if match_ok else "FAIL(" + ", ".join(fail_details) + ")"
+    if not match_ok:
+        match_failures.append((window, fail_details))
+
+    faster = "int" if speedup > 1 else "fft"
+    print(f"{window:>8}  {mean_fft:>{col}.2f} ms  {mean_int:>{col}.2f} ms  "
+          f"{min_fft:>{col}.2f} ms  {min_int:>{col}.2f} ms  "
+          f"{speedup:>6.2f}x {faster}  {match_str}")
+
+print(sep)
+print("speedup >1 means integral is faster; <1 means fft is faster")
+
+# ── Final result-match summary ────────────────────────────────────────────────
+print()
+if match_failures:
+    print("RESULT MISMATCH DETECTED for windows:", [w for w, _ in match_failures])
+    for window, details in match_failures:
+        print(f"  window={window}: {details}")
+else:
+    print(f"Result match: all windows PASSED (|diff| < {ABS_TOL:.0e})")

--- a/tests/test_fss.py
+++ b/tests/test_fss.py
@@ -1,0 +1,104 @@
+import sys
+from pathlib import Path
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+import numpy as np
+from meteothek.calc.fractions import convolve2Dimage
+import logging
+
+from meteothek.calc import fss
+
+# showing DEBUG level messages
+logging.basicConfig(level=logging.DEBUG)  # , format='%(levelname)s - %(name)s - %(asctime)s - %(message)s')
+
+# showing messages in and above the INFO level in pynus.decode
+logging.getLogger("meteothek.calc.fractions").setLevel(logging.DEBUG)
+
+def make_field(shape=(10, 10), nan_fraction=0.1, seed=0):
+    rng = np.random.RandomState(seed)
+    a = rng.rand(*shape)
+    # introduce some NaNs
+    mask = rng.rand(*shape) < nan_fraction
+    a[mask] = np.nan
+    return a
+
+def test_convolve2dfft_basic():
+    field = make_field((10, 10), nan_fraction=0.2, seed=1)
+    kernel = np.ones((3, 3))
+    result = convolve2Dimage(field, kernel, max_missing=0.5, method="fft")
+    # shape preserved
+    assert result.shape == field.shape
+    # result is float and contains nans where appropriate
+    assert np.issubdtype(result.dtype, np.floating)
+    assert np.isnan(result).sum() >= 0
+
+def test_fss_basic_accumulation():
+    # create simple obs and forecast with a clear hotspot
+    obs = np.zeros((10, 10))
+    fcst = np.zeros((10, 10))
+    obs[4:7, 4:7] = 1.0         # obs central square
+    fcst[5:8, 5:8] = 1.0        # fcst shifted by one
+    # include some NaNs at edges
+    obs[0, :] = np.nan
+    fcst[:, 0] = np.nan
+
+    num, denom, score = fss(fcst, obs, threshold=0.5, window=3, thrsd_type="accumulation", max_missing=0.5)
+    print(num, denom, score)
+    # basic sanity checks
+    assert num >= 0
+    assert denom > 0
+    assert 0.0 <= score <= 1.0
+
+# Tolerance for floating-point comparison between integralConv and convolve2DFFT
+_ABS_TOL = 1e-10
+
+def test_integralConv_odd_windows():
+    """integralConv must match convolve2DFFT for odd kernel sizes (3, 5, 7, 9)."""
+    field = make_field((30, 30), nan_fraction=0.1, seed=10)
+    for n in [3, 5, 7, 9]:
+        kernel = np.ones((n, n))
+        ref = convolve2Dimage(field, kernel, max_missing=0.5, method="fft")
+        res = convolve2Dimage(field, kernel, max_missing=0.5, method="integral")
+        diff = np.nanmax(np.abs(ref - res))
+        assert diff < _ABS_TOL, (
+            f"odd window n={n}: max abs diff {diff:.3e} exceeds tolerance {_ABS_TOL}"
+        )
+
+def test_integralConv_even_windows():
+    """integralConv must match convolve2DFFT for even kernel sizes (2, 4, 6, 8)."""
+    field = make_field((30, 30), nan_fraction=0.1, seed=20)
+    for n in [2, 4, 6, 8]:
+        kernel = np.ones((n, n))
+        ref = convolve2Dimage(field, kernel, max_missing=0.5, method="fft")
+        res = convolve2Dimage(field, kernel, max_missing=0.5, method="integral")
+        diff = np.nanmax(np.abs(ref - res))
+        assert diff < _ABS_TOL, (
+            f"even window n={n}: max abs diff {diff:.3e} exceeds tolerance {_ABS_TOL}"
+        )
+
+def test_integralConv_matches_convolve2DFFT_with_nans():
+    """integralConv must match convolve2DFFT for a field with a dense NaN region."""
+    field = make_field((40, 40), nan_fraction=0.2, seed=99)
+    # also add a contiguous NaN block near an edge
+    field[:3, :] = np.nan
+    for n in [3, 4, 5, 6]:
+        kernel = np.ones((n, n))
+        ref = convolve2Dimage(field, kernel, max_missing=0.3, method="fft")
+        res = convolve2Dimage(field, kernel, max_missing=0.3, method="integral")
+        diff = np.nanmax(np.abs(ref - res))
+        assert diff < _ABS_TOL, (
+            f"dense-NaN case n={n}: max abs diff {diff:.3e} exceeds tolerance {_ABS_TOL}"
+        )
+
+if __name__ == "__main__":
+    # run tests directly for quick manual checks
+    test_convolve2dfft_basic()
+    print("convolve2DFFT test passed")
+    test_fss_basic_accumulation()
+    print("fss test passed")
+    test_integralConv_odd_windows()
+    print("integralConv odd-window test passed")
+    test_integralConv_even_windows()
+    print("integralConv even-window test passed")
+    test_integralConv_matches_convolve2DFFT_with_nans()
+    print("integralConv vs convolve2DFFT NaN test passed")


### PR DESCRIPTION
Improved FSS computation by including the integral Image method proposed in Faggian et al. (2015) and optimising the code using Claude Sonnet 4.6 

#### Summary generated by Copilot
This pull request introduces a major enhancement to the 2D convolution and Fractions Skill Score (FSS) calculation routines by adding an alternative convolution method based on integral images, improving performance for small kernels and enabling method selection. It also updates tests and benchmarking to validate correctness and speed, and refines dependency requirements.

New convolution method and API changes:

* Added the `integralImage` function implementing convolution via summed-area tables (integral images), based on recent literature, and integrated it into the FSS workflow. The main convolution function was renamed to `convolve2Dimage` and now supports both `"fft"` and `"integral"` methods via a new `method` parameter. [[1]](diffhunk://#diff-cd3972c5240f5f9eb0457b99418278010523932e57c840c78c57abc1676818bfL14-R14) [[2]](diffhunk://#diff-cd3972c5240f5f9eb0457b99418278010523932e57c840c78c57abc1676818bfL80-R162)
* Updated the `fss` function to accept a `method` parameter, allowing users to select between FFT-based and integral image-based convolution. All internal calls now use the unified `convolve2Dimage` function.

Performance and correctness validation:

* Added a comprehensive benchmark script (`tests/benchmark_fss.py`) to compare speed and numerical accuracy between the two convolution methods across various window sizes, including checks for result equivalence within a strict tolerance.
* Expanded unit tests in `tests/test_fss.py` to verify that the integral image method matches the FFT method for both odd and even kernel sizes, and for fields with NaN regions, ensuring robustness and correctness.